### PR TITLE
Add datetime tooltip to panel created/edited text

### DIFF
--- a/templates/panels/RecentlyCreatedPagesPanel.ss
+++ b/templates/panels/RecentlyCreatedPagesPanel.ss
@@ -18,7 +18,7 @@
 					</a>
 				</td>
 				<td class="link">
-					<a href="admin/pages/edit/show/{$ID}">$Created.Ago</a>
+					<a href="admin/pages/edit/show/{$ID}" title="$Created.Nice">$Created.Ago</a>
 				</td>
 			</tr>
 			<% end_loop %>

--- a/templates/panels/RecentlyEditedPagesPanel.ss
+++ b/templates/panels/RecentlyEditedPagesPanel.ss
@@ -18,7 +18,7 @@
 					</a>
 				</td>
 				<td class="link">
-					<a href="admin/pages/edit/show/{$ID}">$LastEdited.Ago</a>
+					<a href="admin/pages/edit/show/{$ID}" title="$LastEdited.Nice">$LastEdited.Ago</a>
 				</td>
 			</tr>
 			<% end_loop %>


### PR DESCRIPTION
Allows the user to see exactly when something was updated / created without having to edit the page and  open the History tab.