### PR TITLE
Removing subsiteCMSShowInMenu function

### DIFF
--- a/code/admin/DashboardAdmin.php
+++ b/code/admin/DashboardAdmin.php
@@ -52,8 +52,4 @@ class DashboardAdmin extends LeftAndMain implements PermissionProvider {
 
 		return false;
 	}
-
-	public function subsiteCMSShowInMenu() {
-		return true;
-	}
 }


### PR DESCRIPTION
This should be done by adding an extension to the `DashboardAdmin` in a config file on a per case basis.

    DashboardAdmin:
      extensions:
        - SubsiteMenuExtension