### PR TITLE
Adding basic translation support

### DIFF
--- a/code/admin/DashboardAdmin.php
+++ b/code/admin/DashboardAdmin.php
@@ -14,10 +14,11 @@ class DashboardAdmin extends LeftAndMain implements PermissionProvider {
 	}
 
 	public function providePermissions() {
+		$title = _t('DashboardAdmin.MENUTITLE', LeftAndMain::menu_title_for_class('DashboardAdmin'));
 		return array(
 			'CMS_ACCESS_DASHBOARDADMIN' => array(
-				'name' => 'Access to \'Dashboard\' section',
-				'category' => 'Dashboard',
+				'name' => _t('CMSMain.ACCESS', "Access to '{title}' section", array('title' => $title)),
+				'category' => $title,
 				'help' => 'Allow use of the CMS Dashboard'
 			)
 		);

--- a/code/extensions/DashboardSearchExtension.php
+++ b/code/extensions/DashboardSearchExtension.php
@@ -11,11 +11,11 @@ class DashboardSearchExtension extends Extension {
 	function DashboardSearchForm() {
 
 		$fields = FieldList::create(
-			TextField::create('Search', 'Search')->setAttribute('placeholder', 'Search')
+			TextField::create('Search', _t('SearchForm.SEARCH','Search'))->setAttribute('placeholder', _t('SearchForm.SEARCH','Search'))
 		);
 
 		$actions = FieldList::create(
-			FormAction::create('doDashboardSearch', 'Search')
+			FormAction::create('doDashboardSearch', _t('SearchForm.SEARCH','Search'))
 		);
 
 		$requiredFields = RequiredFields::create(
@@ -85,7 +85,7 @@ class DashboardSearchExtension extends Extension {
 		}
 
 		if (count($searchMessageClasses)) {
-			$data['SearchMessage'] = 'Searching for ' . strrev(implode(strrev(' and '), explode(strrev(', '), strrev(implode(', ', $searchMessageClasses)), 2)));
+			$data['SearchMessage'] = 'Searching for ' . strrev(implode(strrev(' &amp; '), explode(strrev(', '), strrev(implode(', ', $searchMessageClasses)), 2)));
 		}
 		$data['SearchResults'] = $searchResults;
 

--- a/lang/de.yml
+++ b/lang/de.yml
@@ -1,0 +1,3 @@
+de:
+  DashboardAdmin:
+    MENUTITLE: Instrumententafel

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -1,0 +1,3 @@
+en:
+  DashboardAdmin:
+    MENUTITLE: Dashboard

--- a/templates/panels/QuickLinksPanel.ss
+++ b/templates/panels/QuickLinksPanel.ss
@@ -3,14 +3,14 @@
 	<% if $CanViewPages %>
 	<a href="admin/pages/">
 		<span class="fa fa-sitemap" aria-hidden="true"></span>
-		Pages
+		<% _t('CMSPagesController.MENUTITLE','Pages') %>
 	</a>
 	<% end_if %>
 
 	<% if $CanViewUsers %>
 	<a href="admin/security/">
 		<span class="fa fa-users" aria-hidden="true"></span>
-		Users
+		<% _t('SecurityAdmin.MENUTITLE','Security') %>
 	</a>
 	<% end_if %>
 
@@ -24,7 +24,7 @@
 	<% if $CanViewSettings %>
 	<a href="admin/settings/">
 		<span class="fa fa-cogs" aria-hidden="true"></span>
-		Settings
+		<% _t('CMSSettingsController.MENUTITLE','Settings') %>
 	</a>
 	<% end_if %>
 


### PR DESCRIPTION
Adding basic translation support. 

This is just a start. This adds translation to the quick links panel, some of the search and to the menu title. Still much to do but this is a start.

This relates to issue #3 