### PR TITLE
Changing accent panel colour to color to match usual US spelling.

### DIFF
--- a/code/admin/DashboardAdmin.php
+++ b/code/admin/DashboardAdmin.php
@@ -12,10 +12,10 @@ class DashboardAdmin extends LeftAndMain implements PermissionProvider {
 		Requirements::css(DASHBOARD_ADMIN_DIR . '/css/dashboard-cms.css');
 		Requirements::javascript(DASHBOARD_ADMIN_DIR . '/javascript/dashboard-js.js');
 
-		if ($panelAccentColour = DashboardAdmin::config()->panel_accent_colour) {
+		if ($panelAccentColor = DashboardAdmin::config()->panel_accent_color) {
 			Requirements::customCSS(<<<CSS
 .cms-content.DashboardAdmin .dashboard-panel {
-	border-top-color: $panelAccentColour;
+	border-top-color: $panelAccentColor;
 }
 CSS
 );

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -12,13 +12,17 @@ See the "require" section of [composer.json](https://github.com/plastyk/silverst
 
 ## Configuration
 
-By default the `UpdatePanel` and `MoreInformationPanel` tell the user to contact their web developer for help. We can make this display the developer name and email address to give a more personalised message. We can also adjust the panel accent colour to match the colour scheme of the website. In our `mysite/_config/config.yml` add:
+By default the `UpdatePanel` and `MoreInformationPanel` tell the user to contact their web developer for help. We can make this display the developer name and email address to give a more personalised message. 
+
+We can also adjust the panel accent colour to match the colour scheme of the website.
+
+In our `mysite/_config/config.yml` add:
 
 ```yml
 DashboardAdmin:
   contact_email: 'email@example.com'
   contact_name: 'Developer Name'
-  panel_accent_colour: '#efbc2a'
+  panel_accent_color: '#efbc2a'
 ```
 ![Dashboard module customisation screenshot](_images/dashboard-module-screenshot-yellow.png)
 


### PR DESCRIPTION
Changing `panel_accent_colour` config variable to `panel_accent_color` as that is the typical spelling of colour in the web world.

As discussed in #15 