### PR TITLE
Changing config.yml module name

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -1,5 +1,5 @@
 ---
-Name: dashboard-adminpanels
+Name: dashboard
 After: 'framework/*','cms/*'
 ---
 AdminRootController:


### PR DESCRIPTION
Changing config.yml module name from `dashboard-adminpanels` to `dashboard`. I think this name is cleaner, simpler and makes more sense. Not sure why we had the long name before.