### PR TITLE
DashboardPanel extension fix

### DIFF
--- a/code/model/DashboardPanel.php
+++ b/code/model/DashboardPanel.php
@@ -5,8 +5,8 @@ abstract class DashboardPanel extends Object {
 	protected $controller;
 
 	public function __construct($controller = null) {
+		parent::__construct();
 		$this->controller = $controller;
-
 		$this->init();
 	}
 


### PR DESCRIPTION
Without the parent constructor call, extensions would not be applied to the DashboardPanel or any descendants.

Fixes issue described in #8 