### PR TITLE
#3 translation support

### DIFF
--- a/code/extensions/DashboardSearchExtension.php
+++ b/code/extensions/DashboardSearchExtension.php
@@ -98,7 +98,7 @@ class DashboardSearchExtension extends Extension
         }
 
         if (count($searchMessageClasses)) {
-            $data['SearchMessage'] = 'Searching for ' . strrev(implode(strrev(' &amp; '), explode(strrev(', '), strrev(implode(', ', $searchMessageClasses)), 2)));
+            $data['SearchMessage'] = _t('SearchPanel.SEARCHINGFOR', 'Searching for') . ' ' . strrev(implode(strrev(' &amp; '), explode(strrev(', '), strrev(implode(', ', $searchMessageClasses)), 2)));
         }
         $data['SearchResults'] = $searchResults;
 

--- a/lang/de.yml
+++ b/lang/de.yml
@@ -1,3 +1,55 @@
 de:
   DashboardAdmin:
     MENUTITLE: Instrumententafel
+  MoreInformationPanel:
+    CONTACT: Kontakt
+    CUSTOMPANELSAVAILABLE: 'Benutzerdefinierte Armaturenbretter sind vorhanden.'
+    IFYOUWOULDLIKETODISCUSS: 'wenn du gerne diskutieren würdest.'
+    YOURWEBDEVELOPER: 'ihr Web-Entwickler'
+  RecentlyCreatedPagesPanel:
+    CREATED: Bearbeitet
+    NORECENTLYCREATEDPAGES: 'Keine Seiten in den letzten sechs Monaten erstellt.'
+    PANELTITLE: 'Kürzlich erstellte Seiten'
+    TITLE: Titel
+  RecentlyEditedPagesPanel:
+    EDITED: Bearbeitet
+    NORECENTLYEDITEDPAGES: 'Keine Seiten in den letzten sechs Monaten bearbeitet.'
+    PANELTITLE: 'Kürzlich bearbeitete Seiten'
+    TITLE: Titel
+  SearchPanel:
+    NAME: Name
+    NORESULTS: 'Leider keine Ergebnisse.'
+    SEARCH: Suche
+    SEARCHINGFOR: 'Auf der Suche nach'
+    SEARCHRESULTSFOR: 'Suchergebnisse für'
+    TITLE: Titel
+    VIEWNEXTPAGE: 'Nächste Seite ansehen'
+    VIEWPAGENUMBER: 'Seitenzahl anzeigen'
+    VIEWPREVIOUSPAGE: 'Vorherige Seite ansehen'
+  UpdatePanel:
+    BUGFIXES: 'Bug fixes'
+    IFYOUWOULDLIKETOUPDATE: 'Wenn Sie auf die neueste Version aktualisieren möchten, kontaktieren Sie bitte'
+    IMPROVEDADMIN: 'Verbesserter Admin-Bereich'
+    LATESTVERSIONIS: 'Die neueste Version ist'
+    MAJORVERSIONMESSAGE: 'Das verfügbare aktualisieren ist ein dur update. Eine dur version aktualisieren besteht aus:'
+    MINORVERSIONMESSAGE: 'Das verfügbare aktualisieren ist ein geringer update. Eine geringer version aktualisieren besteht aus:'
+    NEWFEATURES: 'Neue Funktionen und Erweiterungen'
+    NEWSILVERSTRIPEUPDATESAVAILABLE: 'Neue SilverStripe CMS updates sind verfügbar.'
+    READMORE: 'Weiterlesen'
+    SITEPERFORMANCE: 'Verbesserungen der Standortleistung'
+    SECURITYPATCHES: 'Sicherheits-Patches'
+    SECURITYVERSIONMESSAGE: 'Das verfügbare aktualisieren ist ein sicherheit update. Eine sicherheit version aktualisieren besteht aus:'
+    YOURVERSIONIS: 'Ihre Version ist'
+    YOURWEBDEVELOPER: 'ihr Web-Entwickler'
+  UsefulLinksPanel:
+    GOOGLEANALYTICS: 'Google Analytics'
+    GOOGLEANALYTICSDESCRIPTION: 'Website Traffic Berichte zu sehen, wie viele Menschen besuchen Sie Ihre Website.'
+    METADESCRIPTION: 'Meta Beschreibung Tipps'
+    METADESCRIPTIONDESCRIPTION: 'Nützliche Informationen zum Bestätigen von Meta-Beschreibungen für Ihre Seiten.'
+    PANELTITLE: 'Werkzeuge und Tipps'
+    PIXLR: 'Pixlr'
+    PIXLRDESCRIPTION: 'Online-Bildbearbeitungs-App zur Größenänderung und Bearbeitung von Bildern vor dem Hochladen.'
+    SCREENSHOTSHARING: 'Screenshot teilen'
+    SCREENSHOTSHARINGDESCRIPTION: 'Online-App, um zu helfen, Screenshots Ihrer Website zu helfen, Fehler zu beheben oder für neue Funktionen zu helfen.'
+    WHATSMYBROWSER: "What's my browser"
+    WHATSMYBROWSERDESCRIPTION: 'Informationen darüber, welchen Browser Sie gerade nutzen.'

--- a/lang/de.yml
+++ b/lang/de.yml
@@ -4,52 +4,52 @@ de:
   MoreInformationPanel:
     CONTACT: Kontakt
     CUSTOMPANELSAVAILABLE: 'Benutzerdefinierte Armaturenbretter sind vorhanden.'
-    IFYOUWOULDLIKETODISCUSS: 'wenn du gerne diskutieren würdest.'
+    IFYOUWOULDLIKETODISCUSS: 'wenn du gerne diskutieren wurdest.'
     YOURWEBDEVELOPER: 'ihr Web-Entwickler'
   RecentlyCreatedPagesPanel:
     CREATED: Bearbeitet
     NORECENTLYCREATEDPAGES: 'Keine Seiten in den letzten sechs Monaten erstellt.'
-    PANELTITLE: 'Kürzlich erstellte Seiten'
+    PANELTITLE: 'Kurzlich erstellte Seiten'
     TITLE: Titel
   RecentlyEditedPagesPanel:
     EDITED: Bearbeitet
     NORECENTLYEDITEDPAGES: 'Keine Seiten in den letzten sechs Monaten bearbeitet.'
-    PANELTITLE: 'Kürzlich bearbeitete Seiten'
+    PANELTITLE: 'Kurzlich bearbeitete Seiten'
     TITLE: Titel
   SearchPanel:
     NAME: Name
     NORESULTS: 'Leider keine Ergebnisse.'
     SEARCH: Suche
     SEARCHINGFOR: 'Auf der Suche nach'
-    SEARCHRESULTSFOR: 'Suchergebnisse für'
+    SEARCHRESULTSFOR: 'Suchergebnisse fur'
     TITLE: Titel
-    VIEWNEXTPAGE: 'Nächste Seite ansehen'
+    VIEWNEXTPAGE: 'Nachste Seite ansehen'
     VIEWPAGENUMBER: 'Seitenzahl anzeigen'
     VIEWPREVIOUSPAGE: 'Vorherige Seite ansehen'
   UpdatePanel:
     BUGFIXES: 'Bug fixes'
-    IFYOUWOULDLIKETOUPDATE: 'Wenn Sie auf die neueste Version aktualisieren möchten, kontaktieren Sie bitte'
+    IFYOUWOULDLIKETOUPDATE: 'Wenn Sie auf die neueste Version aktualisieren mochten, kontaktieren Sie bitte'
     IMPROVEDADMIN: 'Verbesserter Admin-Bereich'
     LATESTVERSIONIS: 'Die neueste Version ist'
-    MAJORVERSIONMESSAGE: 'Das verfügbare aktualisieren ist ein dur update. Eine dur version aktualisieren besteht aus:'
-    MINORVERSIONMESSAGE: 'Das verfügbare aktualisieren ist ein geringer update. Eine geringer version aktualisieren besteht aus:'
+    MAJORVERSIONMESSAGE: 'Das verfugbare aktualisieren ist ein dur update. Eine dur version aktualisieren besteht aus:'
+    MINORVERSIONMESSAGE: 'Das verfugbare aktualisieren ist ein geringer update. Eine geringer version aktualisieren besteht aus:'
     NEWFEATURES: 'Neue Funktionen und Erweiterungen'
-    NEWSILVERSTRIPEUPDATESAVAILABLE: 'Neue SilverStripe CMS updates sind verfügbar.'
+    NEWSILVERSTRIPEUPDATESAVAILABLE: 'Neue SilverStripe CMS updates sind verfugbar.'
     READMORE: 'Weiterlesen'
     SITEPERFORMANCE: 'Verbesserungen der Standortleistung'
     SECURITYPATCHES: 'Sicherheits-Patches'
-    SECURITYVERSIONMESSAGE: 'Das verfügbare aktualisieren ist ein sicherheit update. Eine sicherheit version aktualisieren besteht aus:'
+    SECURITYVERSIONMESSAGE: 'Das verfugbare aktualisieren ist ein sicherheit update. Eine sicherheit version aktualisieren besteht aus:'
     YOURVERSIONIS: 'Ihre Version ist'
     YOURWEBDEVELOPER: 'ihr Web-Entwickler'
   UsefulLinksPanel:
     GOOGLEANALYTICS: 'Google Analytics'
     GOOGLEANALYTICSDESCRIPTION: 'Website Traffic Berichte zu sehen, wie viele Menschen besuchen Sie Ihre Website.'
     METADESCRIPTION: 'Meta Beschreibung Tipps'
-    METADESCRIPTIONDESCRIPTION: 'Nützliche Informationen zum Bestätigen von Meta-Beschreibungen für Ihre Seiten.'
+    METADESCRIPTIONDESCRIPTION: 'Nutzliche Informationen zum Bestatigen von Meta-Beschreibungen fur Ihre Seiten.'
     PANELTITLE: 'Werkzeuge und Tipps'
     PIXLR: 'Pixlr'
-    PIXLRDESCRIPTION: 'Online-Bildbearbeitungs-App zur Größenänderung und Bearbeitung von Bildern vor dem Hochladen.'
+    PIXLRDESCRIPTION: 'Online-Bildbearbeitungs-App zur GroBenanderung und Bearbeitung von Bildern vor dem Hochladen.'
     SCREENSHOTSHARING: 'Screenshot teilen'
-    SCREENSHOTSHARINGDESCRIPTION: 'Online-App, um zu helfen, Screenshots Ihrer Website zu helfen, Fehler zu beheben oder für neue Funktionen zu helfen.'
+    SCREENSHOTSHARINGDESCRIPTION: 'Online-App, um zu helfen, Screenshots Ihrer Website zu helfen, Fehler zu beheben oder fur neue Funktionen zu helfen.'
     WHATSMYBROWSER: "What's my browser"
-    WHATSMYBROWSERDESCRIPTION: 'Informationen darüber, welchen Browser Sie gerade nutzen.'
+    WHATSMYBROWSERDESCRIPTION: 'Informationen daruber, welchen Browser Sie gerade nutzen.'

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -1,3 +1,55 @@
 en:
   DashboardAdmin:
     MENUTITLE: Dashboard
+  MoreInformationPanel:
+    CONTACT: Contact
+    CUSTOMPANELSAVAILABLE: 'Custom dashboard panels are available.'
+    IFYOUWOULDLIKETODISCUSS: 'if you would like to discuss.'
+    YOURWEBDEVELOPER: 'your web developer'
+  RecentlyCreatedPagesPanel:
+    CREATED: Created
+    NORECENTLYCREATEDPAGES: 'No pages edited in the last six months.'
+    PANELTITLE: 'Recently created pages'
+    TITLE: Title
+  RecentlyEditedPagesPanel:
+    EDITED: Edited
+    NORECENTLYEDITEDPAGES: 'No pages edited in the last six months.'
+    PANELTITLE: 'Recently edited pages'
+    TITLE: Title
+  SearchPanel:
+    NAME: Name
+    NORESULTS: 'Sorry, no results found.'
+    SEARCH: Search
+    SEARCHINGFOR: 'Searching for'
+    SEARCHRESULTSFOR: 'Search Results for'
+    TITLE: Title
+    VIEWNEXTPAGE: 'View the next page'
+    VIEWPAGENUMBER: 'View page number'
+    VIEWPREVIOUSPAGE: 'View the previous page'
+  UpdatePanel:
+    BUGFIXES: 'Bug fixes'
+    IFYOUWOULDLIKETOUPDATE: 'If you would like to update to the latest version please contact'
+    IMPROVEDADMIN: 'Improved admin section'
+    LATESTVERSIONIS: 'The latest version is'
+    MAJORVERSIONMESSAGE: 'The available update is a major version update. A major version update consists of:'
+    MINORVERSIONMESSAGE: 'The available update is a minor version update. A minor version update consists of:'
+    NEWFEATURES: 'New features and enhancements'
+    NEWSILVERSTRIPEUPDATESAVAILABLE: 'New SilverStripe CMS updates are available.'
+    READMORE: 'Read more'
+    SITEPERFORMANCE: 'Site performance improvements'
+    SECURITYPATCHES: 'Security patches'
+    SECURITYVERSIONMESSAGE: 'The available update is a security release. A security release consists of:'
+    YOURVERSIONIS: 'Your version is'
+    YOURWEBDEVELOPER: 'your web developer'
+  UsefulLinksPanel:
+    GOOGLEANALYTICS: 'Google Analytics'
+    GOOGLEANALYTICSDESCRIPTION: 'Website traffic reports to see how many people are visiting your website.'
+    METADESCRIPTION: 'Meta Description Tips'
+    METADESCRIPTIONDESCRIPTION: 'Useful information on how to best write meta descriptions for your pages.'
+    PANELTITLE: 'Tools and tips'
+    PIXLR: 'Pixlr'
+    PIXLRDESCRIPTION: 'Online photo editing app to resize and edit images before uploading.'
+    SCREENSHOTSHARING: 'Screenshot sharing'
+    SCREENSHOTSHARINGDESCRIPTION: 'Online app to help share screenshots of your website to help fix bugs or for new features.'
+    WHATSMYBROWSER: "What's my browser"
+    WHATSMYBROWSERDESCRIPTION: 'Information on what browser you are currently using.'

--- a/templates/Includes/DashboardSearchPagination.ss
+++ b/templates/Includes/DashboardSearchPagination.ss
@@ -1,17 +1,17 @@
 <% if $Results.MoreThanOnePage %>
 	<ul class="pagination">
 		<% if $Results.NotFirstPage %>
-		<li><a href="$Results.PrevLink" aria-label="View the previous page">&laquo;</a></li>
+		<li><a href="$Results.PrevLink" aria-label="<% _t('SearchPanel.VIEWPREVIOUSPAGE', 'View the previous page') %>">&laquo;</a></li>
 		<% end_if %>
 		<% loop $Results.PaginationSummary %>
 			<% if $PageNum %>
-			<li<% if $CurrentBool %> class="active"<% end_if %>><a href="$Link" aria-label="View page number $PageNum" class="go-to-page">$PageNum</a></li>
+			<li<% if $CurrentBool %> class="active"<% end_if %>><a href="$Link" aria-label="<% _t('SearchPanel.VIEWPAGENUMBER', 'View page number') %> $PageNum" class="go-to-page">$PageNum</a></li>
 			<% else %>
 			<li><span>&hellip;</span></li>
 			<% end_if %>
 		<% end_loop %>
 		<% if $Results.NotLastPage %>
-		<li><a href="$Results.NextLink" aria-label="View the next page">&raquo;</a></li>
+		<li><a href="$Results.NextLink" aria-label="<% _t('SearchPanel.VIEWNEXTPAGE', 'View the next page') %>">&raquo;</a></li>
 		<% end_if %>
 	</ul>
 <% end_if %>

--- a/templates/panels/DashboardSearchFormPanel.ss
+++ b/templates/panels/DashboardSearchFormPanel.ss
@@ -1,6 +1,6 @@
 <div class="dashboard-panel">
 	<div class="dashboard-search">
-		<h3>Search</h3>
+		<h3><% _t('SearchPanel.SEARCH', 'Search') %></h3>
 		$DashboardSearchForm
 	</div>
 </div>

--- a/templates/panels/MoreInformationPanel.ss
+++ b/templates/panels/MoreInformationPanel.ss
@@ -1,9 +1,11 @@
 <div class="dashboard-panel more-information-panel">
 	<p>
 		<span class="fa fa-lightbulb-o" aria-hidden="true"></span>
-		Custom dashboard panels are available.
-		Contact
-		<% if $DashboardContactEmail %><a href="mailto:{$DashboardContactEmail}"><% end_if %><% if $DashboardContactName %>$DashboardContactName<% else %>your web developer<% end_if %><% if $DashboardContactEmail %></a><% end_if %>
-		if you would like to discuss.
+		<% _t('MoreInformationPanel.CUSTOMPANELSAVAILABLE', 'Custom dashboard panels are available.') %>
+		<% _t('MoreInformationPanel.CONTACT', 'Contact') %>
+		<% if $DashboardContactEmail %><a href="mailto:{$DashboardContactEmail}"><% end_if %>
+		<% if $DashboardContactName %>$DashboardContactName<% else %><% _t('MoreInformationPanel.YOURWEBDEVELOPER', 'your web developer') %><% end_if %>
+		<% if $DashboardContactEmail %></a><% end_if %>
+		<% _t('MoreInformationPanel.IFYOUWOULDLIKETODISCUSS', 'if you would like to discuss.') %>
 	</p>
 </div>

--- a/templates/panels/RecentlyCreatedPagesPanel.ss
+++ b/templates/panels/RecentlyCreatedPagesPanel.ss
@@ -1,11 +1,11 @@
 <div class="dashboard-panel">
-	<h3><a href="admin/pages/">Recently created pages</a></h3>
+	<h3><a href="admin/pages/"><% _t('RecentlyCreatedPagesPanel.PANELTITLE', 'Recently created pages') %></a></h3>
 	<% if $Results %>
 	<table class="table">
 		<thead>
 			<tr>
-				<th>Title</th>
-				<th>Created</th>
+				<th><% _t('RecentlyCreatedPagesPanel.TITLE', 'Title') %></th>
+				<th><% _t('RecentlyCreatedPagesPanel.CREATED', 'Created') %></th>
 			</tr>
 		</thead>
 		<tbody>
@@ -25,6 +25,6 @@
 		</tbody>
 	</table>
 	<% else %>
-	<p>No pages created in the last six months.</p>
+	<p><% _t('RecentlyCreatedPagesPanel.NORECENTLYCREATEDPAGES', 'No pages created in the last six months.') %></p>
 	<% end_if %>
 </div>

--- a/templates/panels/RecentlyEditedPagesPanel.ss
+++ b/templates/panels/RecentlyEditedPagesPanel.ss
@@ -1,11 +1,11 @@
 <div class="dashboard-panel">
-	<h3><a href="admin/pages/">Recently edited pages</a></h3>
+	<h3><a href="admin/pages/"><% _t('RecentlyEditedPagesPanel.PANELTITLE', 'Recently edited pages') %></a></h3>
 	<% if $Results %>
 	<table class="table">
 		<thead>
 			<tr>
-				<th>Title</th>
-				<th>Edited</th>
+				<th><% _t('RecentlyEditedPagesPanel.TITLE', 'Title') %></th>
+				<th><% _t('RecentlyEditedPagesPanel.EDITED', 'Edited') %></th>
 			</tr>
 		</thead>
 		<tbody>
@@ -25,6 +25,6 @@
 		</tbody>
 	</table>
 	<% else %>
-	<p>No pages edited in the last six months.</p>
+	<p><% _t('RecentlyEditedPagesPanel.NORECENTLYEDITEDPAGES', 'No pages edited in the last six months.') %></p>
 	<% end_if %>
 </div>

--- a/templates/panels/SearchPanel.ss
+++ b/templates/panels/SearchPanel.ss
@@ -3,7 +3,7 @@
 </div>
 
 <% if $SearchValue %>
-<h2>Search Results for <em>'$SearchValue'</em></h2>
+<h2><% _t('SearchPanel.SEARCHRESULTSFOR', 'Search Results for') %> <em>'$SearchValue'</em></h2>
 
 <% if $SearchMessage %>
 <p class="note">$SearchMessage</p>
@@ -18,7 +18,7 @@
 		<% end_loop %>
 	<% else %>
 	<div class="dashboard-panel">
-		<p>Sorry, no results found.</p>
+		<p><% _t('SearchPanel.NORESULTS', 'Sorry, no results found.') %></p>
 	</div>
 	<% end_if %>
 </div>

--- a/templates/panels/UpdatePanel.ss
+++ b/templates/panels/UpdatePanel.ss
@@ -1,46 +1,48 @@
 <div class="dashboard-panel update-panel closed">
 	<div class="panel-head">
 		<span class="fa fa-exclamation-triangle" aria-hidden="true"></span>
-		<strong>New SilverStripe CMS updates are available.</strong>
+		<strong><% _t('UpdatePanel.NEWSILVERSTRIPEUPDATESAVAILABLE', 'New SilverStripe CMS updates are available.') %></strong>
 		<% if $CurrentSilverStripeVersion %>
-		Your version is {$CurrentSilverStripeVersion}.
+		<% _t('UpdatePanel.YOURVERSIONIS', 'Your version is') %> {$CurrentSilverStripeVersion}.
 		<% end_if %>
 		<% if $LatestSilverStripeVersion %>
-		The latest version is {$LatestSilverStripeVersion}.
+		<% _t('UpdatePanel.LATESTVERSIONIS', 'The latest version is') %> {$LatestSilverStripeVersion}.
 		<% end_if %>
-		<a class="read-more-link">Read more</a>
+		<a class="read-more-link"><% _t('UpdatePanel.READMORE', 'Read more') %></a>
 		<span class="fa fa-angle-right" aria-hidden="true"></span>
 	</div>
 
 	<div class="panel-body">
 		<% if $UpdateVersionLevel == 'major' %>
-		<p>The available update is a major version update. A major version update consists of:</p>
+		<p><% _t('UpdatePanel.MAJORVERSIONMESSAGE', 'The available update is a major version update. A major version update consists of:') %></p>
 		<ul class="list">
-			<li>Security patches</li>
-			<li>Bug fixes</li>
-			<li>New features and enhancements</li>
-			<li>Improved admin section</li>
-			<li>Site performance improvements</li>
+			<li><% _t('UpdatePanel.SECURITYPATCHES', 'Security patches') %></li>
+			<li><% _t('UpdatePanel.BUGFIXES', 'Bug fixes') %></li>
+			<li><% _t('UpdatePanel.NEWFEATURES', 'New features and enhancements') %></li>
+			<li><% _t('UpdatePanel.IMPROVEDADMIN', 'Improved admin section') %></li>
+			<li><% _t('UpdatePanel.SITEPERFORMANCE', 'Site performance improvements') %></li>
 		</ul>
 		<% else_if $UpdateVersionLevel == 'minor' %>
-		<p>The available update is a minor version update. A minor version update consists of:</p>
+		<p><% _t('UpdatePanel.MINORVERSIONMESSAGE', 'The available update is a minor version update. A minor version update consists of:') %></p>
 		<ul class="list">
-			<li>Security patches</li>
-			<li>Bug fixes</li>
-			<li>New features and enhancements</li>
-			<li>Site performance improvements</li>
+			<li><% _t('UpdatePanel.SECURITYPATCHES', 'Security patches') %></li>
+			<li><% _t('UpdatePanel.BUGFIXES', 'Bug fixes') %></li>
+			<li><% _t('UpdatePanel.NEWFEATURES', 'New features and enhancements') %></li>
+			<li><% _t('UpdatePanel.SITEPERFORMANCE', 'Site performance improvements') %></li>
 		</ul>
 		<% else_if $UpdateVersionLevel == 'security' %>
-		<p>The available update is a security release. A security release consists of:</p>
+		<p><% _t('UpdatePanel.SECURITYVERSIONMESSAGE', 'The available update is a security release. A security release consists of:') %></p>
 		<ul class="list">
-			<li>Security patches</li>
-			<li>Bug fixes</li>
+			<li><% _t('UpdatePanel.SECURITYPATCHES', 'Security patches') %></li>
+			<li><% _t('UpdatePanel.BUGFIXES', 'Bug fixes') %></li>
 		</ul>
 		<% end_if %>
 
 		<p>
-			If you would like to update to the latest version please contact
-			<% if $DashboardContactEmail %><a href="mailto:{$DashboardContactEmail}"><% end_if %><% if $DashboardContactName %>$DashboardContactName<% else %>your web developer<% end_if %><% if $DashboardContactEmail %></a><% end_if %>.
+			<% _t('UpdatePanel.IFYOUWOULDLIKETOUPDATE', 'If you would like to update to the latest version please contact') %>
+			<% if $DashboardContactEmail %><a href="mailto:{$DashboardContactEmail}"><% end_if %>
+			<% if $DashboardContactName %>$DashboardContactName<% else %><% _t('UpdatePanel.YOURWEBDEVELOPER', 'your web developer') %><% end_if %>
+			<% if $DashboardContactEmail %></a><% end_if %>.
 		</p>
 	</div>
 </div>

--- a/templates/panels/UsefulLinksPanel.ss
+++ b/templates/panels/UsefulLinksPanel.ss
@@ -1,44 +1,54 @@
 <div class="dashboard-panel">
-	<h3>Tools and tips</h3>
+	<h3><% _t('UsefulLinksPanel.PANELTITLE', 'Tools and tips') %></h3>
 	<table class="table">
 		<tbody>
 			<tr>
 				<td class="link">
 					<a href="//analytics.google.com/analytics/web/" target="_blank">
-						Google Analytics
-						<div class="note">Website traffic reports to see how many people are visiting your website.</div>
+						<% _t('UsefulLinksPanel.GOOGLEANALYTICS', 'Google Analytics') %>
+						<div class="note">
+							<% _t('UsefulLinksPanel.GOOGLEANALYTICSDESCRIPTION', 'Website traffic reports to see how many people are visiting your website.') %>
+						</div>
 					</a>
 				</td>
 			</tr>
 			<tr>
 				<td class="link">
 					<a href="//pixlr.com/web/" target="_blank">
-						Pixlr
-						<div class="note">Online photo editing app to resize and edit images before uploading.</div>
+						<% _t('UsefulLinksPanel.PIXLR', 'Pixlr') %>
+						<div class="note">
+							<% _t('UsefulLinksPanel.PIXLRDESCRIPTION', 'Online photo editing app to resize and edit images before uploading.') %>
+						</div>
 					</a>
 				</td>
 			</tr>
 			<tr>
 				<td class="link">
 					<a href="//moz.com/learn/seo/meta-description#what-is-a" target="_blank">
-						Meta Description Tips
-						<div class="note">Useful information on how to best write meta descriptions for your pages.</div>
+						<% _t('UsefulLinksPanel.METADESCRIPTION', 'Meta Description Tips') %>
+						<div class="note">
+							<% _t('UsefulLinksPanel.METADESCRIPTIONDESCRIPTION', 'Useful information on how to best write meta descriptions for your pages.') %>
+						</div>
 					</a>
 				</td>
 			</tr>
 			<tr>
 				<td class="link">
 					<a href="//snag.gy" target="_blank">
-						Screenshot sharing
-						<div class="note">Online app to help share screenshots of your website to help fix bugs or for new features.</div>
+						<% _t('UsefulLinksPanel.SCREENSHOTSHARING', 'Screenshot sharing') %>
+						<div class="note">
+							<% _t('UsefulLinksPanel.SCREENSHOTSHARINGDESCRIPTION', 'Online app to help share screenshots of your website to help fix bugs or for new features.') %>
+						</div>
 					</a>
 				</td>
 			</tr>
 			<tr>
 				<td class="link">
 					<a href="//whatsmybrowser.org/" target="_blank">
-						What's my browser
-						<div class="note">Information on what browser you are currently using.</div>
+						<% _t('UsefulLinksPanel.WHATSMYBROWSER', "What's my browser") %>
+						<div class="note">
+							<% _t('UsefulLinksPanel.WHATSMYBROWSERDESCRIPTION', 'Information on what browser you are currently using.') %>
+						</div>
 					</a>
 				</td>
 			</tr>

--- a/templates/search/DashboardSearchResultFilePanel.ss
+++ b/templates/search/DashboardSearchResultFilePanel.ss
@@ -1,10 +1,10 @@
 <% if $Results %>
 <div class="dashboard-panel dashboard-search" data-panel-class="$PanelClassName">
-	<h3><a href="admin/assets/">Files</a></h3>
+	<h3><a href="admin/assets/"><% _t('File.PLURALNAME', 'Files') %></a></h3>
 	<table class="table">
 		<thead>
 			<tr>
-				<th>Title</th>
+				<th><% _t('SearchPanel.TITLE', 'Title') %></th>
 			</tr>
 		</thead>
 		<tbody>

--- a/templates/search/DashboardSearchResultMemberPanel.ss
+++ b/templates/search/DashboardSearchResultMemberPanel.ss
@@ -1,10 +1,10 @@
 <% if $Results %>
 <div class="dashboard-panel dashboard-search" data-panel-class="$PanelClassName">
-	<h3><a href="admin/security/">Members</a></h3>
+	<h3><a href="admin/security/"><% _t('Member.PLURALNAME', 'Members') %></a></h3>
 	<table class="table">
 		<thead>
 			<tr>
-				<th>Name</th>
+				<th><% _t('SearchPanel.NAME', 'Name') %></th>
 			</tr>
 		</thead>
 		<tbody>

--- a/templates/search/DashboardSearchResultPagePanel.ss
+++ b/templates/search/DashboardSearchResultPagePanel.ss
@@ -1,10 +1,10 @@
 <% if $Results %>
 <div class="dashboard-panel dashboard-search" data-panel-class="$PanelClassName">
-	<h3><a href="admin/pages/">Pages</a></h3>
+	<h3><a href="admin/pages/"><% _t('Page.PLURALNAME', 'Pages') %></a></h3>
 	<table class="table">
 		<thead>
 			<tr>
-				<th>Title</th>
+				<th><% _t('SearchPanel.TITLE', 'Title') %></th>
 			</tr>
 		</thead>
 		<tbody>


### PR DESCRIPTION
This adds translation support to all the panels. 

Note, there was an issue with the de.yml file. When using non EN characters the whole yml file would be marked as invalid and therefore the whole thing ignored.

I have put in another commit removing these characters for now. Please do not squash the commits so that we have access to the correct de.yml file with correct de characters. 

We will need to investigate and fix the issue later.

(Related to #3)