### PR TITLE
Adding pages menu selection bugfix

### DIFF
--- a/javascript/dashboard-js.js
+++ b/javascript/dashboard-js.js
@@ -17,6 +17,9 @@
 				}
 
 				if (!$('.cms-container').loadPanel(url)) {
+					if (url.indexOf('admin/pages/') !== -1) {
+						$('.cms-menu-list li#Menu-CMSPagesController').select();
+					}
 					return false;
 				}
 


### PR DESCRIPTION
Right now when a page link is clicked on the dashboard, the left menu page option does not highlight `Pages`. It leaves `Dashboard` highlighted. This only occurs for clicking on page edit links from the dashboard.

This JavaScript bugfix detects if the panel refresh url is going to the page section, and if so, calls select on the `Pages` menu item.