### PR TITLE
Removing CMS from composer requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,7 @@
 		}
 	],
 	"require": {
-		"silverstripe/framework": "~3.2",
-		"silverstripe/cms": "~3.2"
+		"silverstripe/framework": "~3.2"
 	},
 	"extra": {
 		"installer-name": "dashboard"


### PR DESCRIPTION
Removing CMS from composer requirements as the dashboard can work on a framework project without the CMS.