### PR TITLE
Default search panel changes

### DIFF
--- a/_config/dashboard-search.yml
+++ b/_config/dashboard-search.yml
@@ -3,7 +3,7 @@ Name: dashboard-search
 After: 'framework/*','cms/*'
 ---
 DashboardAdmin:
-  search_panels:
+  default_search_panels:
     - DashboardSearchResultPagePanel
     - DashboardSearchResultMemberPanel
     - DashboardSearchResultFilePanel

--- a/code/extensions/DashboardSearchExtension.php
+++ b/code/extensions/DashboardSearchExtension.php
@@ -42,6 +42,10 @@ class DashboardSearchExtension extends Extension
         $member = Member::CurrentUser();
         $searchPanelNames = DashboardAdmin::config()->search_panels;
 
+        if (!$searchPanelNames) {
+            $searchPanelNames = DashboardAdmin::config()->default_search_panels;
+        }
+
         $data = array(
             'SearchValue' => Convert::html2raw($searchValue)
         );


### PR DESCRIPTION
Adding `DashboardAdmin::default_search_panels` so that the base search panels can be switched off if the user wants by setting `search_panels`