### PR TITLE
UpdatePanel supports Framework and CMS version checks

### DIFF
--- a/code/panels/UpdatePanel.php
+++ b/code/panels/UpdatePanel.php
@@ -66,16 +66,23 @@ class UpdatePanel extends DashboardPanel
         }
 
         $versions = explode(', ', Injector::inst()->get('LeftAndMain')->CMSVersion());
+        
         if (!empty($versions)) {
-            foreach ($versions as $version) {
-                if (strpos($version, 'Framework: ') !== false) {
-                    $result = substr($version, 11);
-                    break;
+            $versionKeys = array('Framework: ', 'CMS: ');
+            foreach ($versionKeys as $versionKey) {
+                foreach ($versions as $version) {
+                    if (strpos($version, $versionKey) !== false) {
+                        $result = substr($version, strlen($versionKey));
+                        break;
+                    }
                 }
             }
         }
 
-        $updatePanelCache->save($result, 'CurrentSilverStripeVersion');
+        if (is_string($result)) {
+            $updatePanelCache->save($result, 'CurrentSilverStripeVersion');
+        }
+
         return UpdateVersion::from_version_string($result);
     }
 


### PR DESCRIPTION
Fixes the issue introduced in 3.7 where the CMS module overrides some config of Framework so the version string we get back is missing "Framework: " when the CMS module is included.

The code now basically doesn't care if the version is from CMS or Framework but won't fail if it can't get one or the other.

Also a slight change so an exception isn't thrown when trying to cache non-string results.