### PR TITLE
Adding default lifetime to update panel cache

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -15,3 +15,4 @@ SilverStripe\Core\Injector\Injector:
     factory: SilverStripe\Core\Cache\CacheFactory
     constructor:
       namespace: "plastykDashboardCache"
+      defaultLifetime: 3600


### PR DESCRIPTION
The update panel cache seems to last forever. I have added in a config setting to set the cache lifetime to 1 hour.