### PR TITLE
Search one result error fix

### DIFF
--- a/src/Extensions/DashboardSearchExtension.php
+++ b/src/Extensions/DashboardSearchExtension.php
@@ -98,10 +98,12 @@ class DashboardSearchExtension extends Extension
                     && $item->FirstResult->config()->dashboard_automatic_search_redirect;
             })->first();
 
-            $searchResultCMSLink = $singleResultPanel->FirstResult->getSearchResultCMSLink();
+            if ($singleResultPanel) {
+                $searchResultCMSLink = $singleResultPanel->FirstResult->getSearchResultCMSLink();
 
-            if ($singleResultPanel && $searchResultCMSLink) {
-                return $this->owner->redirect($searchResultCMSLink);
+                if ($searchResultCMSLink) {
+                    return $this->owner->redirect($searchResultCMSLink);
+                }
             }
         }
 


### PR DESCRIPTION
There was an error in the search code when one result was found but the class was not set to redirect. The code was calling `$singleResultPanel->FirstResult` when `$singleResultPanel` was null. This fixes that problem by first checking if `$singleResultPanel` is set.