### PR TITLE
Adding extend hook to DashboardAdmin init

### DIFF
--- a/src/Admin/DashboardAdmin.php
+++ b/src/Admin/DashboardAdmin.php
@@ -31,6 +31,8 @@ class DashboardAdmin extends LeftAndMain implements PermissionProvider
 CSS
             );
         }
+
+        $this->extend('updateInit');
     }
 
     public function providePermissions()


### PR DESCRIPTION
This allows developers to change things on the DashboardAdmin init stage, such as allowing the Dashboard to use theme templates.

This helps provide a solution for issue #118 without forcing theme template upon all users of the Dashboard module.