### PR TITLE
Add psr-4 autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,11 @@
         "phpunit/phpunit": "^5.7",
         "squizlabs/php_codesniffer": "*"
     },
+    "autoload": {
+        "psr-4": {
+            "Plastyk\\Dashboard\\": "src/"
+        }
+    },
     "scripts": {
         "lint": "vendor/bin/phpcs src/ tests/",
         "lint-clean": "vendor/bin/phpcbf src/ tests/"


### PR DESCRIPTION
I had an issue where silverstripe's manifest couldn't be flushed, but adding this to the module resolved classloading issues enough for me to flush it. :)