### PR TITLE
Making panel columns go full width on screen sizes smaller than xl.

### DIFF
--- a/docs/en/customisation-new-panels.md
+++ b/docs/en/customisation-new-panels.md
@@ -112,13 +112,13 @@ $showPanel(Plastyk\Dashboard\Panels\UpdatePanel)
 
 	<% if $canViewPanel(RecentlyEditedPropertiesPanel) || $canViewPanel(Plastyk\Dashboard\Panels\RecentlyEditedPagesPanel) || $canViewPanel(Plastyk\Dashboard\Panels\UsefulLinksPanel) %>
 	<div class="row">
-		<div class="col-4">
+		<div class="col-xl-4">
 			$showPanel(RecentlyEditedPropertiesPanel)
 		</div>
-		<div class="col-4">
+		<div class="col-xl-4">
 			$showPanel(Plastyk\Dashboard\Panels\RecentlyEditedPagesPanel)
 		</div>
-		<div class="col-4">
+		<div class="col-xl-4">
 			$showPanel(Plastyk\Dashboard\Panels\UsefulLinksPanel)
 		</div>
 	</div>

--- a/templates/DashboardPanels.ss
+++ b/templates/DashboardPanels.ss
@@ -19,13 +19,13 @@ $showPanel(Plastyk\Dashboard\Panels\UpdatePanel)
 
 	<% if $canViewPanel(Plastyk\Dashboard\Panels\RecentlyEditedPagesPanel) || $canViewPanel(Plastyk\Dashboard\Panels\RecentlyCreatedPagesPanel) || $canViewPanel(Plastyk\Dashboard\Panels\UsefulLinksPanel) %>
 	<div class="row">
-		<div class="col-4">
+		<div class="col-xl-4">
 			$showPanel(Plastyk\Dashboard\Panels\RecentlyEditedPagesPanel)
 		</div>
-		<div class="col-4">
+		<div class="col-xl-4">
 			$showPanel(Plastyk\Dashboard\Panels\RecentlyCreatedPagesPanel)
 		</div>
-		<div class="col-4">
+		<div class="col-xl-4">
 			$showPanel(Plastyk\Dashboard\Panels\UsefulLinksPanel)
 		</div>
 	</div>

--- a/templates/Plastyk/Dashboard/Panels/SearchPanel.ss
+++ b/templates/Plastyk/Dashboard/Panels/SearchPanel.ss
@@ -13,13 +13,13 @@
 	<% if $SearchResultPanels %>
 		<% loop $SearchResultPanels %>
 		<% if $Panel %>
-			<div class="col-4">
+			<div class="col-xl-4">
 				$Panel
 			</div>
 		<% end_if %>
 		<% end_loop %>
 	<% else %>
-	<div class="col-4">
+	<div class="col-xl-4">
 		<div class="dashboard-panel">
 			<p><% _t('SearchPanel.NORESULTS', 'Sorry, no results found.') %></p>
 		</div>

--- a/templates/SearchPanel.ss
+++ b/templates/SearchPanel.ss
@@ -19,13 +19,13 @@
     	<% if $SearchResultPanels %>
     		<% loop $SearchResultPanels %>
     		<% if $Panel %>
-    			<div class="col-4">
+    			<div class="col-xl-4">
     				$Panel
     			</div>
     		<% end_if %>
     		<% end_loop %>
     	<% else %>
-    	<div class="col-4">
+    	<div class="col-xl-4">
     		<div class="dashboard-panel">
     			<p><% _t('SearchPanel.NORESULTS', 'Sorry, no results found.') %></p>
     		</div>


### PR DESCRIPTION
Currently the default panels stay in columns on small screen sizes. On small screens the screen is way too small to accomodate for this.

This change mages the default panels go full screen width on smaller screens.