### PR TITLE
Independent breadcrumb template

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -10,6 +10,10 @@ Plastyk\Dashboard\Admin\DashboardAdmin:
   extensions:
     - Plastyk\Dashboard\Extensions\DashboardSearchExtension
 
+SilverStripe\CMS\Model\SiteTree:
+  extensions:
+    - Plastyk\Dashboard\Extensions\DashboardSiteTreeExtension
+
 SilverStripe\Core\Injector\Injector:
   Psr\SimpleCache\CacheInterface.plastykDashboardCache:
     factory: SilverStripe\Core\Cache\CacheFactory

--- a/src/Extensions/DashboardSiteTreeExtension.php
+++ b/src/Extensions/DashboardSiteTreeExtension.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Plastyk\Dashboard\Extensions;
+
+use SilverStripe\ORM\DataExtension;
+use SilverStripe\View\ArrayData;
+use SilverStripe\View\SSViewer;
+
+class DashboardSiteTreeExtension extends DataExtension
+{
+    public function DashboardBreadcrumbs($maxDepth = 20, $stopAtPageType = false, $showHidden = false, $delimiter = '/')
+    {
+        $pages = $this->owner->getBreadcrumbItems($maxDepth, $stopAtPageType, $showHidden);
+        $pages->remove($this->owner);
+
+        $template = SSViewer::create('Plastyk\Dashboard\Includes\BreadcrumbsTemplate');
+        return $template->process($this->owner->customise(new ArrayData([
+            'Pages' => $pages,
+            'Delimiter' => $delimiter,
+        ])));
+    }
+}

--- a/templates/Plastyk/Dashboard/Includes/BreadcrumbsTemplate.ss
+++ b/templates/Plastyk/Dashboard/Includes/BreadcrumbsTemplate.ss
@@ -1,0 +1,3 @@
+<% if $Pages %>
+	<% loop $Pages %>$MenuTitle.XML <% if not $IsLast %>$Up.Delimiter.RAW <% end_if %><% end_loop %>
+<% end_if %>

--- a/templates/Plastyk/Dashboard/Panels/RecentlyCreatedPagesPanel.ss
+++ b/templates/Plastyk/Dashboard/Panels/RecentlyCreatedPagesPanel.ss
@@ -14,7 +14,7 @@
 				<td class="link">
 					<a href="$CMSEditLink">
 						$Title
-						<div class="note">$Breadcrumbs(4, true)</div>
+						<div class="note">$DashboardBreadcrumbs(4)</div>
 					</a>
 				</td>
 				<td class="link date">

--- a/templates/Plastyk/Dashboard/Panels/RecentlyEditedPagesPanel.ss
+++ b/templates/Plastyk/Dashboard/Panels/RecentlyEditedPagesPanel.ss
@@ -14,7 +14,7 @@
 				<td class="link">
 					<a href="$CMSEditLink">
 						$Title
-						<div class="note">$Breadcrumbs(4, true)</div>
+						<div class="note">$DashboardBreadcrumbs(4)</div>
 					</a>
 				</td>
 				<td class="link date">

--- a/templates/Plastyk/Dashboard/Search/DashboardSearchResultPagePanel.ss
+++ b/templates/Plastyk/Dashboard/Search/DashboardSearchResultPagePanel.ss
@@ -13,7 +13,7 @@
 				<td class="link">
 					<a href="$CMSEditLink">
 						$Title
-						<div class="note">$Breadcrumbs(4, true)</div>
+						<div class="note">$DashboardBreadcrumbs(4)</div>
 					</a>
 				</td>
 			</tr>


### PR DESCRIPTION
Sets the dashboard breadcrumb template to be separate from the main site breadcrumb template.

This previously caused issues if a site had a custom breadcrumb template, as this would be used in the dashboard.

This fixes that problem.